### PR TITLE
Feature/search oclc

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Returns a redirect HTTP response (302) with the corresponding URL in primo-explo
   * `lcn`
   * `isbn`
   * `issn`
+* On error: Redirects to Primo New UI search page of corresponding institution, or to default institution (NYU) view search page if institution parameter is missing.
 
 #### Examples
 
@@ -96,6 +97,7 @@ After fetching corresponding ISBN, ISSN, or title/author data from an OCLC recor
 * Parameters:
   * institution
   * oclc
+* On error: Redirects to Primo New UI search page of corresponding institution with a query containing the OCLC ID alone, or to default institution (NYU) view search page if institution parameter is missing.
 
 #### Examples
 

--- a/common/queryUtils.js
+++ b/common/queryUtils.js
@@ -32,11 +32,14 @@ const generateTitleAuthorQuery = (title, author) => {
   );
 };
 
+const generateOCLCQuery = oclc => `${BASE_SEARCH_URL}query=any,contains,${oclc}&mode=advanced`;
+
 function baseQuery(param, ...ids) {
   const queryFxns = {
     lcn: generateLCNQuery,
     isxn: generateISxNQuery,
-    ["title-author"]: generateTitleAuthorQuery
+    ["title-author"]: generateTitleAuthorQuery,
+    oclc: generateOCLCQuery
   };
 
   const queryFxn = queryFxns[param] || (() => BASE_SEARCH_URL);

--- a/common/queryUtils.js
+++ b/common/queryUtils.js
@@ -2,6 +2,7 @@
 
 const { BASE_SEARCH_URL, BASE_FULLDISPLAY_URL } = require("../config/baseUrls.config.js");
 const INSTITUTIONS_TO_VID = require("../config/institutions.config.js");
+const ADVANCED_MODE = "&mode=advanced";
 
 function institutionView(institution) {
   // account for mis-capitalization
@@ -21,18 +22,18 @@ function searchScope(institution) {
 }
 
 const generateLCNQuery = lcn => `${BASE_FULLDISPLAY_URL}&docid=${lcn}`;
-const generateISxNQuery = isxn => `${BASE_SEARCH_URL}query=isbn,contains,${isxn}&mode=advanced`;
+const generateISxNQuery = isxn => `${BASE_SEARCH_URL}query=isbn,contains,${isxn}${ADVANCED_MODE}`;
+const generateOCLCQuery = oclc => `${BASE_SEARCH_URL}query=any,contains,${oclc}${ADVANCED_MODE}`;
 const generateTitleAuthorQuery = (title, author) => {
   return (
     `${BASE_SEARCH_URL}` +
       (title ? `query=title,exact,${title}` : "") +
       (title && author ? ",AND&" : "") +
       (author ? `query=creator,exact,${author}` : "") +
-      ",&mode=advanced"
+      `,${ADVANCED_MODE}`
   );
 };
 
-const generateOCLCQuery = oclc => `${BASE_SEARCH_URL}query=any,contains,${oclc}&mode=advanced`;
 
 function baseQuery(param, ...ids) {
   const queryFxns = {

--- a/common/targetUri.js
+++ b/common/targetUri.js
@@ -57,9 +57,15 @@ exports.fetchOclcUri = function fetchOclcUri(params, key) {
       return concat(base, scope, vid);
     },
     // if HTTP get goes wrong
-    err => { throw err; })
+    err => {
+      console.error(err.message);
+      return baseQuery("oclc", oclc);
+    })
     // if parseXml goes wrong
-    .catch(err => { throw err; })
+    .catch(err => {
+      console.error(err.message);
+      return baseQuery("oclc", oclc);
+    })
   );
 };
 

--- a/common/targetUri.js
+++ b/common/targetUri.js
@@ -59,12 +59,12 @@ exports.fetchOclcUri = function fetchOclcUri(params, key) {
     // if HTTP get goes wrong
     err => {
       console.error(err.message);
-      return baseQuery("oclc", oclc);
+      return concat(baseQuery("oclc", oclc), scope, vid);
     })
     // if parseXml goes wrong
     .catch(err => {
       console.error(err.message);
-      return baseQuery("oclc", oclc);
+      return concat(baseQuery("oclc", oclc), scope, vid);
     })
   );
 };

--- a/handler.js
+++ b/handler.js
@@ -5,40 +5,28 @@ const { getUri, fetchOclcUri, institutionLandingUri } = require("./common/target
 
 module.exports.persistent = (event, context, callback) =>
   Promise.resolve(event)
-    .then(() => {
-      const params = event.queryStringParameters;
-      return getUri(params);
-    })
+    .then(() => getUri(event.queryStringParameters))
     .catch(err => handleError(err, event))
     .then(uri => handleRedirect(uri, callback));
 
 module.exports.oclc = (event, context, callback) =>
   Promise.resolve(event)
-    .then(() => {
-      const params = event.queryStringParameters;
-      const key = process.env.WORLDCAT_API_KEY;
-      return fetchOclcUri(params, key);
-    })
+    .then(() => fetchOclcUri(event.queryStringParameters, process.env.WORLDCAT_API_KEY))
     .catch(err => handleError(err, event))
     .then(uri => handleRedirect(uri, callback));
 
 
 function handleError(err, event) {
   console.error(err);
-  const institution = (
-    event &&
-    event.queryStringParameters &&
-    event.queryStringParameters.institution
-  ) || null;
-
+  let institution;
+  try { institution = event.queryStringParameters.institution; }
+  catch(_err) { institution = null; }
   return institutionLandingUri(institution);
 }
 
 function handleRedirect(uri, callback) {
   callback(null, {
     statusCode: 302,
-    headers: {
-      Location: uri,
-    }
+    headers: { Location: uri }
   });
 }

--- a/spec/oclc/oclc.spec.js
+++ b/spec/oclc/oclc.spec.js
@@ -105,7 +105,7 @@ describe('OCLC', () => {
         .expectResult(result => {
           expect(result.statusCode).toEqual(302);
 
-          const url = escapeRegExp(BASE_SEARCH_URL);
+          const url = escapeRegExp(`${BASE_SEARCH_URL}query=any,contains,${mockId}`);
           const urlMatcher = new RegExp(url + ".*");
           expect(result.headers.Location).toMatch(urlMatcher);
         })

--- a/spec/oclc/oclc.spec.js
+++ b/spec/oclc/oclc.spec.js
@@ -99,6 +99,7 @@ describe('OCLC', () => {
       it('should redirect to search page', (done) => {
         oclc.event({
           "queryStringParameters": {
+            institution: "nyu",
             oclc: mockId
           }
         })
@@ -108,6 +109,7 @@ describe('OCLC', () => {
           const url = escapeRegExp(`${BASE_SEARCH_URL}query=any,contains,${mockId}`);
           const urlMatcher = new RegExp(url + ".*");
           expect(result.headers.Location).toMatch(urlMatcher);
+          expect(result.headers.Location).toMatch(".*" + "&search_scope=" + ".*" + "&vid=");
         })
         .verify(done);
       });
@@ -138,15 +140,17 @@ describe('OCLC', () => {
       it('should redirect to search page', (done) => {
         oclc.event({
           "queryStringParameters": {
+            institution: "nyu",
             oclc: mockId
           }
         })
         .expectResult(result => {
           expect(result.statusCode).toEqual(302);
 
-          const url = escapeRegExp(BASE_SEARCH_URL);
+          const url = escapeRegExp(`${BASE_SEARCH_URL}query=any,contains,${mockId}`);
           const urlMatcher = new RegExp(url + ".*");
           expect(result.headers.Location).toMatch(urlMatcher);
+          expect(result.headers.Location).toMatch(".*" + "&search_scope=" + ".*" + "&vid=");
         })
         .verify(done);
       });


### PR DESCRIPTION
It appears primo new ui can search oclc ids. Adds ability to instead search with the oclc when isbn or title-author fetch fails.

Example: https://9y7jui1m5j.execute-api.us-east-2.amazonaws.com/dev/persistent/oclc?oclc=51769109xxx&institution=nyu